### PR TITLE
allow for more than 1500 historical data points

### DIFF
--- a/tap_wootric/__init__.py
+++ b/tap_wootric/__init__.py
@@ -59,7 +59,7 @@ def get_access_token():
     CONFIG["access_token"] = data["access_token"]
 
 
-def gen_request(endpoint, startTs=None):
+def gen_request(endpoint):
     url = BASE_URL + endpoint
     params = {
         "per_page": PER_PAGE,
@@ -82,7 +82,6 @@ def gen_request(endpoint, startTs=None):
         data = resp.json()
 
         for row in data:
-            latest_ts = row["created_at"]
             yield row
 
         if len(data) == PER_PAGE:
@@ -90,7 +89,7 @@ def gen_request(endpoint, startTs=None):
             if params["page"] > MAX_RESULT_PAGES:
                 #make a fresh request from our highest observed timestamp so as not to exceed the page count limit
                 params["page"] = 1
-                params["created[gt]"] = get_ts_from_wootric_datestring(latest_ts)
+                params["created[gt]"] = get_ts_from_wootric_datestring(row["created_at"])
         else:
             break
 

--- a/tap_wootric/__init__.py
+++ b/tap_wootric/__init__.py
@@ -38,10 +38,7 @@ def get_start_ts(key):
     return get_ts(get_start(key))
 
 def get_ts(isotime):
-    return int(utils.strptime(isotime).timestamp())   
-
-def get_ts_from_wootric_datestring(datestring):
-    return int(datetime.datetime.strptime(datestring, DATETIME_FMT).timestamp())
+    return int(utils.strptime(isotime).timestamp())
 
 def get_url(endpoint):
     return BASE_URL + endpoint
@@ -89,7 +86,7 @@ def gen_request(endpoint):
             if params["page"] > MAX_RESULT_PAGES:
                 #make a fresh request from our highest observed timestamp so as not to exceed the page count limit
                 params["page"] = 1
-                params["created[gt]"] = get_ts_from_wootric_datestring(row["created_at"])
+                params["created[gt]"] = get_ts(row["created_at"])
         else:
             break
 


### PR DESCRIPTION
When running this tap on the Magento Wootric account, I encountered an error when attempting to retrieve more than 30 pages of data from any API request. 

This update gracefully handles the case when new data continues to appear beyond the 30th page of a request by modifying the request based on the highest timestamp of data processed and re-starting the page count back to 1.

Tested and works great on the Magento account, which has some tables with over 10,000 entries. A single run pulled all historical data without issue.