### PR TITLE
Fix/Handle all errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ ENV/
 
 # Custom stuff
 env.sh
+config.json

--- a/tap_wootric/__init__.py
+++ b/tap_wootric/__init__.py
@@ -75,10 +75,9 @@ def request(url, params):
     req = requests.Request("GET", url, params=params, headers=headers).prepare()
     logger.info("GET {}".format(req.url))
     resp = session.send(req)
-    if resp.status_code == 400:
-        err = resp.json()
+    if resp.status_code >= 400:
         logger.error("GET {}: [{} - {}]".format(req.url, resp.status_code, resp.content))
-        resp.raise_for_status()
+    resp.raise_for_status()
 
     return resp
 


### PR DESCRIPTION
Presently, if the tap encounters an HTTP error response other than 400, it uses the empty response body as a signal that it should move on to the next endpoint (or exit normally if syncing the last endpoint). 

This branch updates the error handling logic to look for and raise exceptions for all error responses. The existing retry logic will attempt to make the request again, and if all subsequent attempts fail, it will kill the process with a non-success status. 