### PR TITLE
Disabled jitter in the backoff function 

### DIFF
--- a/tap_wootric/__init__.py
+++ b/tap_wootric/__init__.py
@@ -70,6 +70,7 @@ def giveup_condition(e):
 @backoff.on_exception(backoff.expo,
                       requests.exceptions.RequestException,
                       max_tries=7,
+                      jitter=None,
                       giveup=giveup_condition,
                       factor=2)
 def request(url, params):


### PR DESCRIPTION
In addition to #10 
Because of jitter, there is a possibility of the tap to fail sometimes because of (randomly) very low delays which do not allow the rate limit to refresh. There are two ways to solve that: increase the retries number or disable the jitter, I chose to disable it. 