### PR TITLE
Implemented the token refresh procedure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,16 @@
 from setuptools import setup
 
 setup(name='tap-wootric',
-      version='0.4.4',
+      version='0.5.0',
       description='Singer.io tap for extracting data from the Wootric API',
       author='Stitch',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_CHANGEME'],
       install_requires=[
-          'singer-python==1.2.0',
+          'singer-python==5.9.0',
           'requests==2.20.0',
-          'backoff==1.3.2'
+          'backoff==1.9.2'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_wootric/__init__.py
+++ b/tap_wootric/__init__.py
@@ -63,8 +63,7 @@ def get_access_token():
     data = resp.json()
 
     CONFIG["access_token"] = data["access_token"]
-    # refresh_after = int(data["expires_in"]) - 60  # refresh in one minute in advance
-    refresh_after = 120
+    refresh_after = int(data["expires_in"]) - 60  # refresh in one minute in advance
     CONFIG["token_expires_at"] = datetime.datetime.utcnow() + datetime.timedelta(seconds=refresh_after)
 
 


### PR DESCRIPTION
# Description of change
Wootric somehow changed its token expiration time, and our integration in Stitch broke as it's now unable to finish sync in 2 hours. 

I've implemented the access token refreshing and updated outdated dependencies.
 https://docs.wootric.com/api/#authentication

# Manual QA steps
 - Run the tap locally, check that it works well and refreshes the token in time
 
# Risks
 - Updated deps
 
# Rollback steps
 - revert this branch